### PR TITLE
Remove read-only files on Windows

### DIFF
--- a/patch_ng.py
+++ b/patch_ng.py
@@ -31,7 +31,7 @@
 from __future__ import print_function
 
 __author__ = "Conan.io <info@conan.io>"
-__version__ = "1.17.4"
+__version__ = "1.17.3"
 __license__ = "MIT"
 __url__ = "https://github.com/conan-io/python-patch"
 

--- a/patch_ng.py
+++ b/patch_ng.py
@@ -31,7 +31,7 @@
 from __future__ import print_function
 
 __author__ = "Conan.io <info@conan.io>"
-__version__ = "1.17.3"
+__version__ = "1.17.4"
 __license__ = "MIT"
 __url__ = "https://github.com/conan-io/python-patch"
 
@@ -1107,13 +1107,13 @@ class PatchSet(object):
           shutil.move(filenamen, backupname)
           if self.write_hunks(backupname if filenameo == filenamen else filenameo, filenamen, p.hunks):
             info("successfully patched %d/%d:\t %s" % (i+1, total, filenamen))
-            os.chmod(backupname, stat.S_IWRITE)
+            os.chmod(backupname, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             os.unlink(backupname)
             if new == b'/dev/null':
               # check that filename is of size 0 and delete it.
               if os.path.getsize(filenamen) > 0:
                 warning("expected patched file to be empty as it's marked as deletion:\t %s" % filenamen)
-              os.chmod(filenamen, stat.S_IWRITE)
+              os.chmod(backupname, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
               os.unlink(filenamen)
           else:
             errors += 1

--- a/patch_ng.py
+++ b/patch_ng.py
@@ -56,6 +56,7 @@ import os
 import posixpath
 import shutil
 import sys
+import stat
 
 
 PY3K = sys.version_info >= (3, 0)
@@ -1106,11 +1107,13 @@ class PatchSet(object):
           shutil.move(filenamen, backupname)
           if self.write_hunks(backupname if filenameo == filenamen else filenameo, filenamen, p.hunks):
             info("successfully patched %d/%d:\t %s" % (i+1, total, filenamen))
+            os.chmod(backupname, stat.S_IWRITE)
             os.unlink(backupname)
             if new == b'/dev/null':
               # check that filename is of size 0 and delete it.
               if os.path.getsize(filenamen) > 0:
                 warning("expected patched file to be empty as it's marked as deletion:\t %s" % filenamen)
+              os.chmod(filenamen, stat.S_IWRITE)
               os.unlink(filenamen)
           else:
             errors += 1

--- a/tests/11permission/11permission.patch
+++ b/tests/11permission/11permission.patch
@@ -1,0 +1,10 @@
+--- some_file
++++ some_file
+@@ -2,6 +2,7 @@
+ line 2
+ line 3
+ line 4
++line 5
+ line 6
+ line 7
+ line 8

--- a/tests/11permission/[result]/some_file
+++ b/tests/11permission/[result]/some_file
@@ -1,0 +1,10 @@
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+line 9
+line 10

--- a/tests/11permission/some_file
+++ b/tests/11permission/some_file
@@ -1,0 +1,9 @@
+line 1
+line 2
+line 3
+line 4
+line 6
+line 7
+line 8
+line 9
+line 10

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -489,7 +489,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(patch_ng.pathstrip(b'path/name.diff', 0), b'path/name.diff')
 
 def remove_tree_force(folder):
-    for root, dirs, files in os.walk(folder):
+    for root, _, files in os.walk(folder):
         for it in files:
             chmod(os.path.join(root, it), stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
     shutil.rmtree(folder, ignore_errors=True)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -490,11 +490,9 @@ class TestHelpers(unittest.TestCase):
 
 def remove_tree_force(folder):
     for root, dirs, files in os.walk(folder):
-        for it in dirs:
-            chmod(os.path.join(root, it), stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
         for it in files:
             chmod(os.path.join(root, it), stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
-    shutil.rmtree(folder)
+    shutil.rmtree(folder, ignore_errors=True)
 
 # ----------------------------------------------------------------------------
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -451,7 +451,7 @@ class TestPatchApply(unittest.TestCase):
         treeroot = join(self.tmpdir, 'rootparent')
         shutil.copytree(join(TESTS, '11permission'), treeroot)
         pto = patch_ng.fromfile(join(TESTS, '11permission', '11permission.patch'))
-        some_file = join(TESTS, '11permission', 'some_file')
+        some_file = join(treeroot, 'some_file')
         chmod(some_file, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
         self.assertTrue(pto.apply(root=treeroot))
         self.assertTrue(os.stat(some_file).st_mode, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -37,7 +37,8 @@ import re
 import shutil
 import unittest
 import copy
-from os import listdir
+import stat
+from os import listdir, chmod
 from os.path import abspath, dirname, exists, join, isdir, isfile
 from tempfile import mkdtemp
 try:
@@ -171,9 +172,7 @@ class TestPatchFiles(unittest.TestCase):
         self._assert_dirs_equal(join(basepath, "[result]"),
                                 tmpdir,
                                 ignore=["%s.patch" % testname, ".svn", ".gitkeep", "[result]"])
-
-
-      shutil.rmtree(tmpdir)
+      remove_tree_force(tmpdir)
       return 0
 
 
@@ -362,7 +361,7 @@ class TestPatchApply(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.save_cwd)
-        shutil.rmtree(self.tmpdir)
+        remove_tree_force(self.tmpdir)
 
     def tmpcopy(self, filenames):
         """copy file(s) from test_dir to self.tmpdir"""
@@ -447,10 +446,15 @@ class TestPatchApply(unittest.TestCase):
         self.assertFalse(pto.apply(root=treeroot, fuzz=False))
 
     def test_unlink_backup_windows(self):
+        """ Apply patch to a read-only file and don't change its filemode
+        """
         treeroot = join(self.tmpdir, 'rootparent')
         shutil.copytree(join(TESTS, '11permission'), treeroot)
-        pto = patch_ng.fromfile(join(TESTS, '11permission/11permission.patch'))
+        pto = patch_ng.fromfile(join(TESTS, '11permission', '11permission.patch'))
+        some_file = join(TESTS, '11permission', 'some_file')
+        chmod(some_file, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
         self.assertTrue(pto.apply(root=treeroot))
+        self.assertTrue(os.stat(some_file).st_mode, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
 
 class TestHelpers(unittest.TestCase):
@@ -483,6 +487,14 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(patch_ng.pathstrip(b'path/to/test/name.diff', 2), b'test/name.diff')
         self.assertEqual(patch_ng.pathstrip(b'path/name.diff', 1), b'name.diff')
         self.assertEqual(patch_ng.pathstrip(b'path/name.diff', 0), b'path/name.diff')
+
+def remove_tree_force(folder):
+    for root, dirs, files in os.walk(folder):
+        for it in dirs:
+            chmod(os.path.join(root, it), stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+        for it in files:
+            chmod(os.path.join(root, it), stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    shutil.rmtree(folder)
 
 # ----------------------------------------------------------------------------
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -446,6 +446,12 @@ class TestPatchApply(unittest.TestCase):
         self.assertTrue(pto.apply(root=treeroot, fuzz=True))
         self.assertFalse(pto.apply(root=treeroot, fuzz=False))
 
+    def test_unlink_backup_windows(self):
+        treeroot = join(self.tmpdir, 'rootparent')
+        shutil.copytree(join(TESTS, '11permission'), treeroot)
+        pto = patch_ng.fromfile(join(TESTS, '11permission/11permission.patch'))
+        self.assertTrue(pto.apply(root=treeroot))
+
 
 class TestHelpers(unittest.TestCase):
     # unittest setting


### PR DESCRIPTION
Hi!

When removing read-only files (os.unlink) on Windows, the current behavior is raise an exception. To fix this situation, we need to add write permission to that file.

Related issue: https://github.com/conan-io/conan/issues/6676

We should release a new tag after this PR, and of course, release it on pypi.org (automatic operation related to current version).

Also, Conan will require a new patch version, because we are using a specific version for patch-ng there: https://github.com/conan-io/conan/blob/1.23.0/conans/requirements.txt#L6