### PR TITLE
Fix PatchSet.dump

### DIFF
--- a/patch_ng.py
+++ b/patch_ng.py
@@ -1284,16 +1284,18 @@ class PatchSet(object):
     return True
 
 
-  def dump(self):
+  def dump(self, stream=None):
+    if stream is None:
+      stream = sys.stdout.buffer
     for p in self.items:
       for headline in p.header:
-        print(headline.rstrip('\n'))
-      print('--- ' + p.source)
-      print('+++ ' + p.target)
+        stream.write(headline)
+      stream.write(b'--- ' + p.source + b'\n')
+      stream.write(b'+++ ' + p.target + b'\n')
       for h in p.hunks:
-        print('@@ -%s,%s +%s,%s @@' % (h.startsrc, h.linessrc, h.starttgt, h.linestgt))
+        stream.write(('@@ -%d,%d +%d,%d @@\n' % (h.startsrc, h.linessrc, h.starttgt, h.linestgt)).encode())
         for line in h.text:
-          print(line.rstrip('\n'))
+          stream.write(line)
 
 
 def main():

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -319,6 +319,30 @@ class TestPatchParse(unittest.TestCase):
         self.assertEqual(pto.diffstat(), output, "Output doesn't match")
 
 
+class TestPatchDump(unittest.TestCase):
+    def setUp(self):
+        self.save_cwd = getcwdu()
+        self.tmpdir = mkdtemp(prefix=self.__class__.__name__)
+        os.chdir(self.tmpdir)
+
+    def test_fromstring(self):
+        patch_in = join(TESTS, "07google_code_wiki.patch")
+        patch_out = "patch.out"
+        pst = patch_ng.fromfile(patch_in)
+        import io
+        s = io.BytesIO()
+        pst.dump(s)
+        print(s.getvalue().decode())
+        with open(patch_out, "wb") as f:
+            pst.dump(f)
+        with open(patch_in, "r") as fin:
+            reference = fin.read()
+        with open(patch_out, "r") as fout:
+            dumpout = fout.read()
+        self.assertEqual([l.strip() for l in reference.splitlines()],
+                         [l.strip() for l in dumpout.splitlines()])
+
+
 class TestPatchSetDetection(unittest.TestCase):
     def test_svn_detected(self):
         pto = patch_ng.fromfile(join(TESTS, "01uni_multi/01uni_multi.patch"))


### PR DESCRIPTION
`PatchSet.dump` requires all variables to be `byte` objects.

Fix this + add a simple test.

Note that I choose a simple patch file to compare in the test, because the patch does not save comments on the patch lines starting with `---`, `+++` and `@@`.