### PR TITLE
Update CI badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status Travis CI](https://travis-ci.org/conan-io/python-patch-ng.svg?branch=master)](https://travis-ci.org/conan-io/python-patch-ng)
-[![Build status Appveyor](https://ci.appveyor.com/api/projects/status/i4r6lf62slvx82db?svg=true)](https://ci.appveyor.com/project/ConanCIintegration/python-patch-ng)
+[![CI Status](https://github.com/conan-io/python-patch-ng/actions/workflows/workflow.yml/badge.svg)](https://github.com/conan-io/python-patch-ng/actions/workflows/workflow.yml)
 [![PyPI](https://img.shields.io/pypi/v/patch-ng)](https://pypi.python.org/pypi/patch-ng)
 
 ## Patch NG (New Generation)


### PR DESCRIPTION
Replaced Travis and Appveyor badges by Github actions. 