### PR TITLE
Fixed: incorrect GIT format patches detection

### DIFF
--- a/patch_ng.py
+++ b/patch_ng.py
@@ -761,8 +761,10 @@ class PatchSet(object):
         if p.header[idx].startswith(b"diff --git"):
           break
       if p.header[idx].startswith(b'diff --git a/'):
+        # git-format-patch with --full-index generates full blob index, which is 40 symbols length
+        # shortcut index length may vary, seems to depend on the project size
         if (idx+1 < len(p.header)
-            and re.match(b'(?:index \\w{7}..\\w{7} \\d{6}|new file mode \\d*)', p.header[idx+1])):
+            and re.match(b'(?:index \\w{7,40}..\\w{7,40} \\d{6}|new file mode \\d*)', p.header[idx+1])):
           if DVCS:
             return GIT
 


### PR DESCRIPTION
This is a proposal to solve #38 
Index length is not fixed to 7 and can vary up to 40 characters.