### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,23 @@
+name: Bug Report
+description: Report a bug, something does not work as it's supposed to
+title: '[bug]'
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Include the bug description and environment details
+      placeholder: |
+        Environment details: OS, Python version, patch-ng version, etc.
+        Description: xxxx
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: How to reproduce it
+      description: It would be great to know how to reproduce it locally
+      placeholder: |
+        Commands to reproduce it, remote repository to use it locally, etc. Every detail is more than welcome!
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: Feature Request
+description: Request a new feature or suggest a change
+title: '[feature] SHORT DESCRIPTION'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit a request.
+        **Please don't forget to update the issue title.**
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: What is your suggestion?
+      description: Please be as specific as possible!
+      placeholder: Hi! I would like for patch-ng to be able to ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,17 @@
+name: Question
+description: If something needs clarification
+title: '[question] SHORT DESCRIPTION'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill your question.
+        **Please don't forget to update the issue title.**
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      description: Please be as specific as possible!
+      placeholder: Hi! I have a question regarding ...
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### Description of your Pull Request
+
+<!-- Replace this text with a description of your pull request. -->
+
+- [ ] Refer to the issue that supports this Pull Request.
+- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
+- [ ] I've tested locally that my code works.
+- [ ] I've added relevant tests to verify that my code works.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,113 @@
-*.pyc
-build
-dist
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+venv/
+.venv/
+*.egg-info/
+.installed.cfg
+*.egg
+pip-wheel-metadata/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+.pydev*
+.project
+
+# IDEs #
+########
+.metadata
 .idea
-patch_ng.egg-info
+.history/
+
+conan.conf
+*default_package_folder
+
+#Eclipse folder
+.settings
+
+#VScode folder
+.vscode
+
+#Generated certificate file
+cacert.pem
+
+#linux backup and vim files
+*~
+.*.sw?
+Session.vim
+
+#Pyinstaller generated binaries
+/pyinstaller
+
+# Run tests in docker in current dir
+.bash_history
+.conan_server/
+.sudo_as_admin_successful
+.noseids
+
+# add excluded
+!conans/client/build
+!conan/tools/build
+!test/unittests/client/build
+!test/unittests/tools/build


### PR DESCRIPTION
For better classification of information and pre-asking about testing PRs.

These templates were copied from conan-io/conan project, and adapted to use this project name instead. 