### PR TITLE
Add test to validate empty patch

### DIFF
--- a/tests/emptypatches/create755.patch
+++ b/tests/emptypatches/create755.patch
@@ -1,0 +1,21 @@
+From 39fdfb57a112a3b00cc352b45d17aba4f0f58005 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@mail.com>
+Date: Wed, 1 Oct 2025 12:39:25 +0200
+Subject: [PATCH] Add quotes.txt
+
+Signed-off-by: John Doe <john.doe@mail.com>
+---
+ quote.txt | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100755 quote.txt
+
+diff --git a/quote.txt b/quote.txt
+new file mode 100755
+index 0000000000000000000000000000000000000000..cbfafe956ec35385f5b728daa390603ff71f1933
+--- /dev/null
++++ b/quote.txt
+@@ -0,0 +1 @@
++post malam segetem, serendum est.
+-- 
+2.51.0
+

--- a/tests/emptypatches/update644.patch
+++ b/tests/emptypatches/update644.patch
@@ -1,0 +1,16 @@
+From 9a6f61c8cabffc01811605577d6d276a07c8bb95 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@mail.com>
+Date: Fri, 3 Oct 2025 08:57:43 +0200
+Subject: [PATCH] Change file permission
+
+Signed-off-by: John Doe <john.doe@mail.com>
+---
+ quote.txt | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ mode change 100755 => 100644 quote.txt
+
+diff --git a/quote.txt b/quote.txt
+old mode 100755
+new mode 100644
+--
+2.51.0


### PR DESCRIPTION
### Description of your Pull Request

The issue #35 brings the case when an empty patch is tried to be applied, it fails in the end.

This is a scenario when doing chmod or similar only to a file, where no line is changed in the end. As a result, patch-ng can not understand it as it parser looks for the index `@@ -0,0 +1 @@` (and similar).

This PR provides a test to validate that case, but does not bring a solution, because it will affect not only the patch parse logic profoundly, but also its regex. I'm afraid is too risky trying to fix it, but without breaking something else later, as this fork is supposed to be more conservative.


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've tested locally that my code works.
- [x] I've added relevant tests to verify that my code works.
